### PR TITLE
[RTC-18] Don't raise in `protect` and `unprotect`

### DIFF
--- a/c_src/ex_libsrtp/srtp.c
+++ b/c_src/ex_libsrtp/srtp.c
@@ -255,14 +255,7 @@ UNIFEX_TERM protect(UnifexEnv *env, UnifexState *state, char *what,
                                      use_mki, mki_index);
   if (serr) {
     unifex_payload_free_clone(protected);
-    switch(serr) {
-      case srtp_err_status_replay_fail:
-	return protect_result_error_srtp_err_status_replay_fail(env);
-      case srtp_err_status_replay_old:
-	return protect_result_error_srtp_err_status_replay_old(env);
-      default:
-	return protect_result_error_other(env, srtp_util_strerror(serr));
-      }
+    return protect_result_error(env, srtp_util_strerror_short(serr));
   }
 
 
@@ -292,19 +285,7 @@ UNIFEX_TERM unprotect(UnifexEnv *env, UnifexState *state, char *what,
                                     use_mki);
   if (serr) {
     unifex_payload_free_clone(unprotected);
-
-    switch (serr) {
-    case srtp_err_status_auth_fail:
-      return unprotect_result_error_auth_fail(env);
-    case srtp_err_status_replay_fail:
-      return unprotect_result_error_replay_fail(env);
-    case srtp_err_status_bad_mki:
-      return unprotect_result_error_bad_mki(env);
-    case srtp_err_status_replay_old:
-        return unprotect_result_error_replay_too_old(env);
-    default:
-      return unprotect_result_error_other(env, srtp_util_strerror(serr));
-    }
+    return unprotect_result_error(env, srtp_util_strerror_short(serr));
   }
 
   err = unifex_payload_realloc(unprotected, len);

--- a/c_src/ex_libsrtp/srtp.c
+++ b/c_src/ex_libsrtp/srtp.c
@@ -303,7 +303,7 @@ UNIFEX_TERM unprotect(UnifexEnv *env, UnifexState *state, char *what,
     case srtp_err_status_replay_old:
         return unprotect_result_error_replay_too_old(env);
     default:
-      return unifex_raise(env, srtp_util_strerror(serr));
+      return unprotect_result_error_other(env, srtp_util_strerror(serr));
     }
   }
 

--- a/c_src/ex_libsrtp/srtp.c
+++ b/c_src/ex_libsrtp/srtp.c
@@ -257,7 +257,6 @@ UNIFEX_TERM protect(UnifexEnv *env, UnifexState *state, char *what,
     return protect_result_error(env, srtp_util_error_to_atom(serr));
   }
 
-
   err = unifex_payload_realloc(protected, len);
   if (!err) {
     unifex_payload_free_clone(protected);

--- a/c_src/ex_libsrtp/srtp.c
+++ b/c_src/ex_libsrtp/srtp.c
@@ -2,7 +2,6 @@
 #include "srtp_util.h"
 #include "unifex_util.h"
 
-#include <srtp2/srtp.h>
 #include <stdbool.h>
 
 #ifdef _WIN32
@@ -255,7 +254,7 @@ UNIFEX_TERM protect(UnifexEnv *env, UnifexState *state, char *what,
                                      use_mki, mki_index);
   if (serr) {
     unifex_payload_free_clone(protected);
-    return protect_result_error(env, srtp_util_strerror_short(serr));
+    return protect_result_error(env, srtp_util_error_to_atom(serr));
   }
 
 
@@ -285,7 +284,7 @@ UNIFEX_TERM unprotect(UnifexEnv *env, UnifexState *state, char *what,
                                     use_mki);
   if (serr) {
     unifex_payload_free_clone(unprotected);
-    return unprotect_result_error(env, srtp_util_strerror_short(serr));
+    return unprotect_result_error(env, srtp_util_error_to_atom(serr));
   }
 
   err = unifex_payload_realloc(unprotected, len);

--- a/c_src/ex_libsrtp/srtp.c
+++ b/c_src/ex_libsrtp/srtp.c
@@ -2,6 +2,7 @@
 #include "srtp_util.h"
 #include "unifex_util.h"
 
+#include <srtp2/srtp.h>
 #include <stdbool.h>
 
 #ifdef _WIN32
@@ -254,8 +255,16 @@ UNIFEX_TERM protect(UnifexEnv *env, UnifexState *state, char *what,
                                      use_mki, mki_index);
   if (serr) {
     unifex_payload_free_clone(protected);
-    return unifex_raise(env, srtp_util_strerror(serr));
+    switch(serr) {
+      case srtp_err_status_replay_fail:
+	return protect_result_error_srtp_err_status_replay_fail(env);
+      case srtp_err_status_replay_old:
+	return protect_result_error_srtp_err_status_replay_old(env);
+      default:
+	return protect_result_error_other(env, srtp_util_strerror(serr));
+      }
   }
+
 
   err = unifex_payload_realloc(protected, len);
   if (!err) {

--- a/c_src/ex_libsrtp/srtp.spec.exs
+++ b/c_src/ex_libsrtp/srtp.spec.exs
@@ -35,14 +35,8 @@ spec update(
 
 spec protect(state, what :: atom, payload, use_mki :: bool, mki_index :: unsigned) ::
        {:ok :: label, payload}
-       | {:error :: label, :srtp_err_status_replay_old :: label}
-       | {:error :: label, :srtp_err_status_replay_fail :: label}
-       | {:error :: label, {:other :: label, string}}
+       | {:error :: label, reason :: atom}
 
 spec unprotect(state, what :: atom, payload, use_mki :: bool) ::
        {:ok :: label, payload}
-       | {:error :: label, :auth_fail :: label}
-       | {:error :: label, :replay_fail :: label}
-       | {:error :: label, :bad_mki :: label}
-       | {:error :: label, :replay_too_old :: label}
-       | {:error :: label, {:other :: label, string}}
+       | {:error :: label, reason :: atom}

--- a/c_src/ex_libsrtp/srtp.spec.exs
+++ b/c_src/ex_libsrtp/srtp.spec.exs
@@ -45,3 +45,4 @@ spec unprotect(state, what :: atom, payload, use_mki :: bool) ::
        | {:error :: label, :replay_fail :: label}
        | {:error :: label, :bad_mki :: label}
        | {:error :: label, :replay_too_old :: label}
+       | {:error :: label, {:other :: label, string}}

--- a/c_src/ex_libsrtp/srtp.spec.exs
+++ b/c_src/ex_libsrtp/srtp.spec.exs
@@ -35,6 +35,9 @@ spec update(
 
 spec protect(state, what :: atom, payload, use_mki :: bool, mki_index :: unsigned) ::
        {:ok :: label, payload}
+       | {:error :: label, :srtp_err_status_replay_old :: label}
+       | {:error :: label, :srtp_err_status_replay_fail :: label}
+       | {:error :: label, {:other :: label, string}}
 
 spec unprotect(state, what :: atom, payload, use_mki :: bool) ::
        {:ok :: label, payload}

--- a/c_src/ex_libsrtp/srtp_util.c
+++ b/c_src/ex_libsrtp/srtp_util.c
@@ -2,20 +2,20 @@
 #include <string.h>
 
 bool srtp_util_unmarshal_ssrc(int ssrc_type, unsigned int ssrc,
-    srtp_ssrc_t *result) {
+                              srtp_ssrc_t *result) {
   switch (ssrc_type) {
-    case ssrc_specific:
-      result->type = ssrc_specific;
-      result->value = ssrc;
-      return true;
-    case ssrc_any_inbound:
-      result->type = ssrc_any_inbound;
-      return true;
-    case ssrc_any_outbound:
-      result->type = ssrc_any_outbound;
-      return true;
-    default:
-      return false;
+  case ssrc_specific:
+    result->type = ssrc_specific;
+    result->value = ssrc;
+    return true;
+  case ssrc_any_inbound:
+    result->type = ssrc_any_inbound;
+    return true;
+  case ssrc_any_outbound:
+    result->type = ssrc_any_outbound;
+    return true;
+  default:
+    return false;
   }
 }
 
@@ -121,127 +121,127 @@ bool srtp_util_set_crypto_policy_from_crypto_profile_atom(
 
 const char *srtp_util_strerror(srtp_err_status_t err) {
   switch (err) {
-    case srtp_err_status_ok:
-      return "srtp: nothing to report";
-    case srtp_err_status_fail:
-      return "srtp: unspecified failure";
-    case srtp_err_status_bad_param:
-      return "srtp: unsupported parameter";
-    case srtp_err_status_alloc_fail:
-      return "srtp: couldn't allocate memory";
-    case srtp_err_status_dealloc_fail:
-      return "srtp: couldn't deallocate properly";
-    case srtp_err_status_init_fail:
-      return "srtp: couldn't initialize";
-    case srtp_err_status_terminus:
-      return "srtp: can't process as much data as requested";
-    case srtp_err_status_auth_fail:
-      return "srtp: authentication failure";
-    case srtp_err_status_cipher_fail:
-      return "srtp: cipher failure";
-    case srtp_err_status_replay_fail:
-      return "srtp: replay check failed (bad index)";
-    case srtp_err_status_replay_old:
-      return "srtp: replay check failed (index too old)";
-    case srtp_err_status_algo_fail:
-      return "srtp: algorithm failed test routine";
-    case srtp_err_status_no_such_op:
-      return "srtp: unsupported operation";
-    case srtp_err_status_no_ctx:
-      return "srtp: no appropriate context found";
-    case srtp_err_status_cant_check:
-      return "srtp: unable to perform desired validation";
-    case srtp_err_status_key_expired:
-      return "srtp: can't use key any more";
-    case srtp_err_status_socket_err:
-      return "srtp: error in use of socket";
-    case srtp_err_status_signal_err:
-      return "srtp: error in use POSIX signals";
-    case srtp_err_status_nonce_bad:
-      return "srtp: nonce check failed";
-    case srtp_err_status_read_fail:
-      return "srtp: couldn't read data";
-    case srtp_err_status_write_fail:
-      return "srtp: couldn't write data";
-    case srtp_err_status_parse_err:
-      return "srtp: error parsing data";
-    case srtp_err_status_encode_err:
-      return "srtp: error encoding data";
-    case srtp_err_status_semaphore_err:
-      return "srtp: error while using semaphores";
-    case srtp_err_status_pfkey_err:
-      return "srtp: error while using pfkey";
-    case srtp_err_status_bad_mki:
-      return "srtp: error MKI present in packet is invalid";
-    case srtp_err_status_pkt_idx_old:
-      return "srtp: packet index is too old to consider";
-    case srtp_err_status_pkt_idx_adv:
-      return "srtp: packet index advanced, reset needed";
-    default:
-      return "srtp: unknown error";
+  case srtp_err_status_ok:
+    return "srtp: nothing to report";
+  case srtp_err_status_fail:
+    return "srtp: unspecified failure";
+  case srtp_err_status_bad_param:
+    return "srtp: unsupported parameter";
+  case srtp_err_status_alloc_fail:
+    return "srtp: couldn't allocate memory";
+  case srtp_err_status_dealloc_fail:
+    return "srtp: couldn't deallocate properly";
+  case srtp_err_status_init_fail:
+    return "srtp: couldn't initialize";
+  case srtp_err_status_terminus:
+    return "srtp: can't process as much data as requested";
+  case srtp_err_status_auth_fail:
+    return "srtp: authentication failure";
+  case srtp_err_status_cipher_fail:
+    return "srtp: cipher failure";
+  case srtp_err_status_replay_fail:
+    return "srtp: replay check failed (bad index)";
+  case srtp_err_status_replay_old:
+    return "srtp: replay check failed (index too old)";
+  case srtp_err_status_algo_fail:
+    return "srtp: algorithm failed test routine";
+  case srtp_err_status_no_such_op:
+    return "srtp: unsupported operation";
+  case srtp_err_status_no_ctx:
+    return "srtp: no appropriate context found";
+  case srtp_err_status_cant_check:
+    return "srtp: unable to perform desired validation";
+  case srtp_err_status_key_expired:
+    return "srtp: can't use key any more";
+  case srtp_err_status_socket_err:
+    return "srtp: error in use of socket";
+  case srtp_err_status_signal_err:
+    return "srtp: error in use POSIX signals";
+  case srtp_err_status_nonce_bad:
+    return "srtp: nonce check failed";
+  case srtp_err_status_read_fail:
+    return "srtp: couldn't read data";
+  case srtp_err_status_write_fail:
+    return "srtp: couldn't write data";
+  case srtp_err_status_parse_err:
+    return "srtp: error parsing data";
+  case srtp_err_status_encode_err:
+    return "srtp: error encoding data";
+  case srtp_err_status_semaphore_err:
+    return "srtp: error while using semaphores";
+  case srtp_err_status_pfkey_err:
+    return "srtp: error while using pfkey";
+  case srtp_err_status_bad_mki:
+    return "srtp: error MKI present in packet is invalid";
+  case srtp_err_status_pkt_idx_old:
+    return "srtp: packet index is too old to consider";
+  case srtp_err_status_pkt_idx_adv:
+    return "srtp: packet index advanced, reset needed";
+  default:
+    return "srtp: unknown error";
   }
 }
 
 const char *srtp_util_error_to_atom(srtp_err_status_t err) {
-  switch(err) {
-    case srtp_err_status_ok:
-      // hardly an error, but let's leave it here for completeness sake
-     return "ok";
-    case srtp_err_status_fail:
-      return "fail";
-    case srtp_err_status_bad_param:
-      return "bad_param";
-    case srtp_err_status_alloc_fail:
-      return "alloc_fail";
-    case srtp_err_status_dealloc_fail:
-      return "dealloc_fail";
-    case srtp_err_status_init_fail:
-      return "init_fail";
-    case srtp_err_status_terminus:
-      return "terminus";
-    case srtp_err_status_auth_fail:
-      return "auth_fail";
-    case srtp_err_status_cipher_fail:
-      return "cipher_fail";
-    case srtp_err_status_replay_fail:
-      return "replay_fail";
-    case srtp_err_status_replay_old:
-      return "replay_old";
-    case srtp_err_status_algo_fail:
-      return "algo_fail";
-    case srtp_err_status_no_such_op:
-      return "no_such_op";
-    case srtp_err_status_no_ctx:
-      return "no_ctx";
-    case srtp_err_status_cant_check:
-      return "cant_check";
-    case srtp_err_status_key_expired:
-      return "key_expired";
-    case srtp_err_status_socket_err:
-      return "socket_err";
-    case srtp_err_status_signal_err:
-      return "signal_err";
-    case srtp_err_status_nonce_bad:
-      return "nonce_bad";
-    case srtp_err_status_read_fail:
-      return "read_fail";
-    case srtp_err_status_write_fail:
-      return "write_fail";
-    case srtp_err_status_parse_err:
-      return "parse_err";
-    case srtp_err_status_encode_err:
-      return "encode_err";
-    case srtp_err_status_semaphore_err:
-      return "semaphore_err";
-    case srtp_err_status_pfkey_err:
-      return "pfkey_err";
-    case srtp_err_status_bad_mki:
-      return "bad_mki";
-    case srtp_err_status_pkt_idx_old:
-      return "pkt_idx_old";
-    case srtp_err_status_pkt_idx_adv:
-      return "pkt_idx_adv";
-    default:
-      return "unknown";
+  switch (err) {
+  case srtp_err_status_ok:
+    // hardly an error, but let's leave it here for completeness sake
+    return "ok";
+  case srtp_err_status_fail:
+    return "fail";
+  case srtp_err_status_bad_param:
+    return "bad_param";
+  case srtp_err_status_alloc_fail:
+    return "alloc_fail";
+  case srtp_err_status_dealloc_fail:
+    return "dealloc_fail";
+  case srtp_err_status_init_fail:
+    return "init_fail";
+  case srtp_err_status_terminus:
+    return "terminus";
+  case srtp_err_status_auth_fail:
+    return "auth_fail";
+  case srtp_err_status_cipher_fail:
+    return "cipher_fail";
+  case srtp_err_status_replay_fail:
+    return "replay_fail";
+  case srtp_err_status_replay_old:
+    return "replay_old";
+  case srtp_err_status_algo_fail:
+    return "algo_fail";
+  case srtp_err_status_no_such_op:
+    return "no_such_op";
+  case srtp_err_status_no_ctx:
+    return "no_ctx";
+  case srtp_err_status_cant_check:
+    return "cant_check";
+  case srtp_err_status_key_expired:
+    return "key_expired";
+  case srtp_err_status_socket_err:
+    return "socket_err";
+  case srtp_err_status_signal_err:
+    return "signal_err";
+  case srtp_err_status_nonce_bad:
+    return "nonce_bad";
+  case srtp_err_status_read_fail:
+    return "read_fail";
+  case srtp_err_status_write_fail:
+    return "write_fail";
+  case srtp_err_status_parse_err:
+    return "parse_err";
+  case srtp_err_status_encode_err:
+    return "encode_err";
+  case srtp_err_status_semaphore_err:
+    return "semaphore_err";
+  case srtp_err_status_pfkey_err:
+    return "pfkey_err";
+  case srtp_err_status_bad_mki:
+    return "bad_mki";
+  case srtp_err_status_pkt_idx_old:
+    return "pkt_idx_old";
+  case srtp_err_status_pkt_idx_adv:
+    return "pkt_idx_adv";
+  default:
+    return "unknown";
   }
 }

--- a/c_src/ex_libsrtp/srtp_util.c
+++ b/c_src/ex_libsrtp/srtp_util.c
@@ -1,5 +1,4 @@
 #include "srtp_util.h"
-#include <srtp2/srtp.h>
 #include <string.h>
 
 bool srtp_util_unmarshal_ssrc(int ssrc_type, unsigned int ssrc,
@@ -183,65 +182,66 @@ const char *srtp_util_strerror(srtp_err_status_t err) {
   }
 }
 
-const char *srtp_util_strerror_short(srtp_err_status_t err) {
+const char *srtp_util_error_to_atom(srtp_err_status_t err) {
   switch(err) {
     case srtp_err_status_ok:
-      return "srtp_err_status_ok";
+      // hardly an error, but let's leave it here for completeness sake
+     return "ok";
     case srtp_err_status_fail:
-      return "srtp_err_status_fail";
+      return "fail";
     case srtp_err_status_bad_param:
-      return "srtp_err_status_bad_param";
+      return "bad_param";
     case srtp_err_status_alloc_fail:
-      return "srtp_err_status_alloc_fail";
+      return "alloc_fail";
     case srtp_err_status_dealloc_fail:
-      return "srtp_err_status_dealloc_fail";
+      return "dealloc_fail";
     case srtp_err_status_init_fail:
-      return "srtp_err_status_init_fail";
+      return "init_fail";
     case srtp_err_status_terminus:
-      return "srtp_err_status_terminus";
+      return "terminus";
     case srtp_err_status_auth_fail:
-      return "srtp_err_status_auth_fail";
+      return "auth_fail";
     case srtp_err_status_cipher_fail:
-      return "srtp_err_status_cipher_fail";
+      return "cipher_fail";
     case srtp_err_status_replay_fail:
-      return "srtp_err_status_replay_fail";
+      return "replay_fail";
     case srtp_err_status_replay_old:
-      return "srtp_err_status_replay_old";
+      return "replay_old";
     case srtp_err_status_algo_fail:
-      return "srtp_err_status_algo_fail";
+      return "algo_fail";
     case srtp_err_status_no_such_op:
-      return "srtp_err_status_no_such_op";
+      return "no_such_op";
     case srtp_err_status_no_ctx:
-      return "srtp_err_status_no_ctx";
+      return "no_ctx";
     case srtp_err_status_cant_check:
-      return "srtp_err_status_cant_check";
+      return "cant_check";
     case srtp_err_status_key_expired:
-      return "srtp_err_status_key_expired";
+      return "key_expired";
     case srtp_err_status_socket_err:
-      return "srtp_err_status_socket_err";
+      return "socket_err";
     case srtp_err_status_signal_err:
-      return "srtp_err_status_signal_err";
+      return "signal_err";
     case srtp_err_status_nonce_bad:
-      return "srtp_err_status_nonce_bad";
+      return "nonce_bad";
     case srtp_err_status_read_fail:
-      return "srtp_err_status_read_fail";
+      return "read_fail";
     case srtp_err_status_write_fail:
-      return "srtp_err_status_write_fail";
+      return "write_fail";
     case srtp_err_status_parse_err:
-      return "srtp_err_status_parse_err";
+      return "parse_err";
     case srtp_err_status_encode_err:
-      return "srtp_err_status_encode_err";
+      return "encode_err";
     case srtp_err_status_semaphore_err:
-      return "srtp_err_status_semaphore_err";
+      return "semaphore_err";
     case srtp_err_status_pfkey_err:
-      return "srtp_err_status_pfkey_err";
+      return "pfkey_err";
     case srtp_err_status_bad_mki:
-      return "srtp_err_status_bad_mki";
+      return "bad_mki";
     case srtp_err_status_pkt_idx_old:
-      return "srtp_err_status_pkt_idx_old";
+      return "pkt_idx_old";
     case srtp_err_status_pkt_idx_adv:
-      return "srtp_err_status_pkt_idx_adv";
+      return "pkt_idx_adv";
     default:
-      return "srtp_unknown_error";
+      return "unknown";
   }
 }

--- a/c_src/ex_libsrtp/srtp_util.c
+++ b/c_src/ex_libsrtp/srtp_util.c
@@ -183,63 +183,65 @@ const char *srtp_util_strerror(srtp_err_status_t err) {
   }
 }
 
-const char *strp_util_srterror_short(srtp_err_status_t err) {
+const char *srtp_util_strerror_short(srtp_err_status_t err) {
   switch(err) {
-    case 0:
+    case srtp_err_status_ok:
       return "srtp_err_status_ok";
-    case 1:
+    case srtp_err_status_fail:
       return "srtp_err_status_fail";
-    case 2:
+    case srtp_err_status_bad_param:
       return "srtp_err_status_bad_param";
-    case 3:
+    case srtp_err_status_alloc_fail:
       return "srtp_err_status_alloc_fail";
-    case 4:
+    case srtp_err_status_dealloc_fail:
       return "srtp_err_status_dealloc_fail";
-    case 5:
+    case srtp_err_status_init_fail:
       return "srtp_err_status_init_fail";
-    case 6:
+    case srtp_err_status_terminus:
       return "srtp_err_status_terminus";
-    case 7:
+    case srtp_err_status_auth_fail:
       return "srtp_err_status_auth_fail";
-    case 8:
+    case srtp_err_status_cipher_fail:
       return "srtp_err_status_cipher_fail";
-    case 9:
+    case srtp_err_status_replay_fail:
       return "srtp_err_status_replay_fail";
-    case 10:
+    case srtp_err_status_replay_old:
       return "srtp_err_status_replay_old";
-    case 11:
+    case srtp_err_status_algo_fail:
       return "srtp_err_status_algo_fail";
-    case 12:
+    case srtp_err_status_no_such_op:
       return "srtp_err_status_no_such_op";
-    case 13:
+    case srtp_err_status_no_ctx:
       return "srtp_err_status_no_ctx";
-    case 14:
+    case srtp_err_status_cant_check:
       return "srtp_err_status_cant_check";
-    case 15:
+    case srtp_err_status_key_expired:
       return "srtp_err_status_key_expired";
-    case 16:
+    case srtp_err_status_socket_err:
       return "srtp_err_status_socket_err";
-    case 17:
+    case srtp_err_status_signal_err:
       return "srtp_err_status_signal_err";
-    case 18:
+    case srtp_err_status_nonce_bad:
       return "srtp_err_status_nonce_bad";
-    case 19:
+    case srtp_err_status_read_fail:
       return "srtp_err_status_read_fail";
-    case 20:
+    case srtp_err_status_write_fail:
       return "srtp_err_status_write_fail";
-    case 21:
+    case srtp_err_status_parse_err:
       return "srtp_err_status_parse_err";
-    case 22:
+    case srtp_err_status_encode_err:
       return "srtp_err_status_encode_err";
-    case 23:
+    case srtp_err_status_semaphore_err:
       return "srtp_err_status_semaphore_err";
-    case 24:
+    case srtp_err_status_pfkey_err:
       return "srtp_err_status_pfkey_err";
-    case 25:
+    case srtp_err_status_bad_mki:
       return "srtp_err_status_bad_mki";
-    case 26:
+    case srtp_err_status_pkt_idx_old:
       return "srtp_err_status_pkt_idx_old";
-    case 27:
+    case srtp_err_status_pkt_idx_adv:
       return "srtp_err_status_pkt_idx_adv";
+    default:
+      return "srtp_unknown_error";
   }
 }

--- a/c_src/ex_libsrtp/srtp_util.c
+++ b/c_src/ex_libsrtp/srtp_util.c
@@ -1,21 +1,22 @@
 #include "srtp_util.h"
+#include <srtp2/srtp.h>
 #include <string.h>
 
 bool srtp_util_unmarshal_ssrc(int ssrc_type, unsigned int ssrc,
-                              srtp_ssrc_t *result) {
+    srtp_ssrc_t *result) {
   switch (ssrc_type) {
-  case ssrc_specific:
-    result->type = ssrc_specific;
-    result->value = ssrc;
-    return true;
-  case ssrc_any_inbound:
-    result->type = ssrc_any_inbound;
-    return true;
-  case ssrc_any_outbound:
-    result->type = ssrc_any_outbound;
-    return true;
-  default:
-    return false;
+    case ssrc_specific:
+      result->type = ssrc_specific;
+      result->value = ssrc;
+      return true;
+    case ssrc_any_inbound:
+      result->type = ssrc_any_inbound;
+      return true;
+    case ssrc_any_outbound:
+      result->type = ssrc_any_outbound;
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -121,63 +122,124 @@ bool srtp_util_set_crypto_policy_from_crypto_profile_atom(
 
 const char *srtp_util_strerror(srtp_err_status_t err) {
   switch (err) {
-  case srtp_err_status_ok:
-    return "srtp: nothing to report";
-  case srtp_err_status_fail:
-    return "srtp: unspecified failure";
-  case srtp_err_status_bad_param:
-    return "srtp: unsupported parameter";
-  case srtp_err_status_alloc_fail:
-    return "srtp: couldn't allocate memory";
-  case srtp_err_status_dealloc_fail:
-    return "srtp: couldn't deallocate properly";
-  case srtp_err_status_init_fail:
-    return "srtp: couldn't initialize";
-  case srtp_err_status_terminus:
-    return "srtp: can't process as much data as requested";
-  case srtp_err_status_auth_fail:
-    return "srtp: authentication failure";
-  case srtp_err_status_cipher_fail:
-    return "srtp: cipher failure";
-  case srtp_err_status_replay_fail:
-    return "srtp: replay check failed (bad index)";
-  case srtp_err_status_replay_old:
-    return "srtp: replay check failed (index too old)";
-  case srtp_err_status_algo_fail:
-    return "srtp: algorithm failed test routine";
-  case srtp_err_status_no_such_op:
-    return "srtp: unsupported operation";
-  case srtp_err_status_no_ctx:
-    return "srtp: no appropriate context found";
-  case srtp_err_status_cant_check:
-    return "srtp: unable to perform desired validation";
-  case srtp_err_status_key_expired:
-    return "srtp: can't use key any more";
-  case srtp_err_status_socket_err:
-    return "srtp: error in use of socket";
-  case srtp_err_status_signal_err:
-    return "srtp: error in use POSIX signals";
-  case srtp_err_status_nonce_bad:
-    return "srtp: nonce check failed";
-  case srtp_err_status_read_fail:
-    return "srtp: couldn't read data";
-  case srtp_err_status_write_fail:
-    return "srtp: couldn't write data";
-  case srtp_err_status_parse_err:
-    return "srtp: error parsing data";
-  case srtp_err_status_encode_err:
-    return "srtp: error encoding data";
-  case srtp_err_status_semaphore_err:
-    return "srtp: error while using semaphores";
-  case srtp_err_status_pfkey_err:
-    return "srtp: error while using pfkey";
-  case srtp_err_status_bad_mki:
-    return "srtp: error MKI present in packet is invalid";
-  case srtp_err_status_pkt_idx_old:
-    return "srtp: packet index is too old to consider";
-  case srtp_err_status_pkt_idx_adv:
-    return "srtp: packet index advanced, reset needed";
-  default:
-    return "srtp: unknown error";
+    case srtp_err_status_ok:
+      return "srtp: nothing to report";
+    case srtp_err_status_fail:
+      return "srtp: unspecified failure";
+    case srtp_err_status_bad_param:
+      return "srtp: unsupported parameter";
+    case srtp_err_status_alloc_fail:
+      return "srtp: couldn't allocate memory";
+    case srtp_err_status_dealloc_fail:
+      return "srtp: couldn't deallocate properly";
+    case srtp_err_status_init_fail:
+      return "srtp: couldn't initialize";
+    case srtp_err_status_terminus:
+      return "srtp: can't process as much data as requested";
+    case srtp_err_status_auth_fail:
+      return "srtp: authentication failure";
+    case srtp_err_status_cipher_fail:
+      return "srtp: cipher failure";
+    case srtp_err_status_replay_fail:
+      return "srtp: replay check failed (bad index)";
+    case srtp_err_status_replay_old:
+      return "srtp: replay check failed (index too old)";
+    case srtp_err_status_algo_fail:
+      return "srtp: algorithm failed test routine";
+    case srtp_err_status_no_such_op:
+      return "srtp: unsupported operation";
+    case srtp_err_status_no_ctx:
+      return "srtp: no appropriate context found";
+    case srtp_err_status_cant_check:
+      return "srtp: unable to perform desired validation";
+    case srtp_err_status_key_expired:
+      return "srtp: can't use key any more";
+    case srtp_err_status_socket_err:
+      return "srtp: error in use of socket";
+    case srtp_err_status_signal_err:
+      return "srtp: error in use POSIX signals";
+    case srtp_err_status_nonce_bad:
+      return "srtp: nonce check failed";
+    case srtp_err_status_read_fail:
+      return "srtp: couldn't read data";
+    case srtp_err_status_write_fail:
+      return "srtp: couldn't write data";
+    case srtp_err_status_parse_err:
+      return "srtp: error parsing data";
+    case srtp_err_status_encode_err:
+      return "srtp: error encoding data";
+    case srtp_err_status_semaphore_err:
+      return "srtp: error while using semaphores";
+    case srtp_err_status_pfkey_err:
+      return "srtp: error while using pfkey";
+    case srtp_err_status_bad_mki:
+      return "srtp: error MKI present in packet is invalid";
+    case srtp_err_status_pkt_idx_old:
+      return "srtp: packet index is too old to consider";
+    case srtp_err_status_pkt_idx_adv:
+      return "srtp: packet index advanced, reset needed";
+    default:
+      return "srtp: unknown error";
+  }
+}
+
+const char *strp_util_srterror_short(srtp_err_status_t err) {
+  switch(err) {
+    case 0:
+      return "srtp_err_status_ok";
+    case 1:
+      return "srtp_err_status_fail";
+    case 2:
+      return "srtp_err_status_bad_param";
+    case 3:
+      return "srtp_err_status_alloc_fail";
+    case 4:
+      return "srtp_err_status_dealloc_fail";
+    case 5:
+      return "srtp_err_status_init_fail";
+    case 6:
+      return "srtp_err_status_terminus";
+    case 7:
+      return "srtp_err_status_auth_fail";
+    case 8:
+      return "srtp_err_status_cipher_fail";
+    case 9:
+      return "srtp_err_status_replay_fail";
+    case 10:
+      return "srtp_err_status_replay_old";
+    case 11:
+      return "srtp_err_status_algo_fail";
+    case 12:
+      return "srtp_err_status_no_such_op";
+    case 13:
+      return "srtp_err_status_no_ctx";
+    case 14:
+      return "srtp_err_status_cant_check";
+    case 15:
+      return "srtp_err_status_key_expired";
+    case 16:
+      return "srtp_err_status_socket_err";
+    case 17:
+      return "srtp_err_status_signal_err";
+    case 18:
+      return "srtp_err_status_nonce_bad";
+    case 19:
+      return "srtp_err_status_read_fail";
+    case 20:
+      return "srtp_err_status_write_fail";
+    case 21:
+      return "srtp_err_status_parse_err";
+    case 22:
+      return "srtp_err_status_encode_err";
+    case 23:
+      return "srtp_err_status_semaphore_err";
+    case 24:
+      return "srtp_err_status_pfkey_err";
+    case 25:
+      return "srtp_err_status_bad_mki";
+    case 26:
+      return "srtp_err_status_pkt_idx_old";
+    case 27:
+      return "srtp_err_status_pkt_idx_adv";
   }
 }

--- a/c_src/ex_libsrtp/srtp_util.h
+++ b/c_src/ex_libsrtp/srtp_util.h
@@ -12,4 +12,4 @@ bool srtp_util_set_crypto_policy_from_crypto_profile_atom(
     char *crypto_profile, srtp_crypto_policy_t *policy);
 
 
-const char *srtp_util_strerror_short(srtp_err_status_t err);
+const char *srtp_util_error_to_atom(srtp_err_status_t err);

--- a/c_src/ex_libsrtp/srtp_util.h
+++ b/c_src/ex_libsrtp/srtp_util.h
@@ -4,7 +4,12 @@
 #include <stdbool.h>
 
 const char *srtp_util_strerror(srtp_err_status_t err);
+
 bool srtp_util_unmarshal_ssrc(int ssrc_type, unsigned int ssrc,
                               srtp_ssrc_t *result);
+
 bool srtp_util_set_crypto_policy_from_crypto_profile_atom(
     char *crypto_profile, srtp_crypto_policy_t *policy);
+
+
+const char *srtp_util_strerror_short(srtp_err_status_t err);

--- a/c_src/ex_libsrtp/srtp_util.h
+++ b/c_src/ex_libsrtp/srtp_util.h
@@ -11,5 +11,4 @@ bool srtp_util_unmarshal_ssrc(int ssrc_type, unsigned int ssrc,
 bool srtp_util_set_crypto_policy_from_crypto_profile_atom(
     char *crypto_profile, srtp_crypto_policy_t *policy);
 
-
 const char *srtp_util_error_to_atom(srtp_err_status_t err);

--- a/lib/ex_libsrtp.ex
+++ b/lib/ex_libsrtp.ex
@@ -158,7 +158,7 @@ defmodule ExLibSRTP do
   Other errors indicate a failure in cryptographic mechanisms, please refer to [libsrtp documentation](https://github.com/cisco/libsrtp)
   """
   @spec unprotect(t(), protected :: binary(), use_mki :: boolean()) ::
-          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t}
+          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t()}
   def unprotect(ref(native) = _srtp, protected, use_mki \\ false) do
     Native.unprotect(native, :rtp, protected, use_mki)
   end
@@ -174,7 +174,7 @@ defmodule ExLibSRTP do
   Other errors indicate issues in the cryptographic mechanisms.
   """
   @spec unprotect_rtcp(t(), protected :: binary(), use_mki :: boolean()) ::
-          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t}
+          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t()}
   def unprotect_rtcp(ref(native) = _srtp, protected, use_mki \\ false) do
     Native.unprotect(native, :rtcp, protected, use_mki)
   end

--- a/lib/ex_libsrtp.ex
+++ b/lib/ex_libsrtp.ex
@@ -114,6 +114,7 @@ defmodule ExLibSRTP do
   Most common errors:
   - `:replay_fail` - packet has either a duplicate sequence number or its sequence number has an old rollover counter (roc)
   - `:replay_old` - packet has a sequence number with current roc, but it is older than the beginning of the encryption window.
+  - `:bad_mki` - provided MKI is not a known MKI id
 
   Other errors indicate a failure in cryptographic mechanisms, please refer to [libsrtp documentation](https://github.com/cisco/libsrtp)
   """
@@ -129,6 +130,11 @@ defmodule ExLibSRTP do
     Native.protect(native, :rtp, unprotected, true, mki_index)
   end
 
+  @doc """
+  Protect RTCP packet.
+
+  All errors indicate an error in the cryptographic mechanisms.
+  """
   @spec protect_rtcp(t(), unprotected :: binary(), mki_index :: pos_integer() | nil) ::
           {:ok, protected :: binary()} | {:error, libsrtp_error_t()}
   def protect_rtcp(srtp, unprotected, mki_index \\ nil)
@@ -157,6 +163,16 @@ defmodule ExLibSRTP do
     Native.unprotect(native, :rtp, protected, use_mki)
   end
 
+  @doc """
+  Unprotect RTCP packet.
+
+  Expected errors:
+  - `:auth_fail` - SRTCP message has failed the message authentication check.
+  - `:replay_fail` - SRTCP message is a duplicate
+  - `:bad_mki` - provided MKI is not a known MKI id
+
+  Other errors indicate issues in the cryptographic mechanisms.
+  """
   @spec unprotect_rtcp(t(), protected :: binary(), use_mki :: boolean()) ::
           {:ok, unprotected :: binary()} | {:error, libsrtp_error_t}
   def unprotect_rtcp(ref(native) = _srtp, protected, use_mki \\ false) do

--- a/lib/ex_libsrtp.ex
+++ b/lib/ex_libsrtp.ex
@@ -12,6 +12,42 @@ defmodule ExLibSRTP do
 
   alias ExLibSRTP.{Native, Policy}
 
+  @typedoc """
+  Type describing possible errors that might be returned by ExLibSRTP functions.
+
+  Meaning of these might vary depending on the function. For explanation, please refer to
+  appropriate documentation.
+
+  This type is based on [`srtp_err_status_t` enum](https://github.com/cisco/libsrtp/blob/004b7bb85caf4f52a7cc8a7aad94d9d1706e8b6d/include/srtp.h#L164).
+  """
+  @type libsrtp_error_t() ::
+          :fail
+          | :bad_param
+          | :alloc_fail
+          | :dealloc_fail
+          | :init_fail
+          | :terminus
+          | :auth_fail
+          | :cipher_fail
+          | :replay_fail
+          | :replay_old
+          | :algo_fail
+          | :no_such_op
+          | :no_ctx
+          | :cant_check
+          | :key_expired
+          | :socket_err
+          | :signal_err
+          | :nonce_bad
+          | :read_fail
+          | :write_fail
+          | :parse_err
+          | :encode_err
+          | :semaphore_err
+          | :pfkey_err
+          | :bad_mki
+          | :pkt_idx_old
+
   @opaque t :: {__MODULE__, native :: reference}
 
   @type ssrc_t :: 0..4_294_967_295
@@ -72,8 +108,17 @@ defmodule ExLibSRTP do
     )
   end
 
+  @doc """
+  Protect RTP packet.
+
+  Most common errors:
+  - `:replay_fail` - packet has either a duplicate sequence number or its sequence number has an old rollover counter (roc)
+  - `:replay_old` - packet has a sequence number with current roc, but it is older than the beginning of the encryption window.
+
+  Other errors indicate a failure in cryptographic mechanisms, please refer to [libsrtp documentation](https://github.com/cisco/libsrtp)
+  """
   @spec protect(t(), unprotected :: binary(), mki_index :: pos_integer() | nil) ::
-          {:ok, protected :: binary()}
+          {:ok, protected :: binary()} | {:error, libsrtp_error_t()}
   def protect(srtp, unprotected, mki_index \\ nil)
 
   def protect(ref(native), unprotected, nil) do
@@ -85,7 +130,7 @@ defmodule ExLibSRTP do
   end
 
   @spec protect_rtcp(t(), unprotected :: binary(), mki_index :: pos_integer() | nil) ::
-          {:ok, protected :: binary()}
+          {:ok, protected :: binary()} | {:error, libsrtp_error_t()}
   def protect_rtcp(srtp, unprotected, mki_index \\ nil)
 
   def protect_rtcp(ref(native), unprotected, nil) do
@@ -96,14 +141,24 @@ defmodule ExLibSRTP do
     Native.protect(native, :rtcp, unprotected, true, mki_index)
   end
 
+  @doc """
+  Unprotect RTP packet.
+
+  Most common errors:
+  - `:replay_fail` - packet has either a duplicate sequence number or its sequence number has an old rollover counter (roc)
+  - `:replay_old` - packet has a sequence number with current roc, but it is older than the beginning of the decryption window.
+  - `:auth_fail` - packet has failed the message authentication check
+
+  Other errors indicate a failure in cryptographic mechanisms, please refer to [libsrtp documentation](https://github.com/cisco/libsrtp)
+  """
   @spec unprotect(t(), protected :: binary(), use_mki :: boolean()) ::
-          {:ok, unprotected :: binary()} | {:error, :auth_fail | :reply_fail | :bad_mki}
+          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t}
   def unprotect(ref(native) = _srtp, protected, use_mki \\ false) do
     Native.unprotect(native, :rtp, protected, use_mki)
   end
 
   @spec unprotect_rtcp(t(), protected :: binary(), use_mki :: boolean()) ::
-          {:ok, unprotected :: binary()} | {:error, :auth_fail | :reply_fail | :bad_mki}
+          {:ok, unprotected :: binary()} | {:error, libsrtp_error_t}
   def unprotect_rtcp(ref(native) = _srtp, protected, use_mki \\ false) do
     Native.unprotect(native, :rtcp, protected, use_mki)
   end


### PR DESCRIPTION
This PR changes the behavior of `protect` and `unprotect` function so that they never raise.

The change is motivated by the following reasons:
1. From the perspective of WebRTC, it isn't desirable to always crash the entire endpoint, whenever a `protect` error occurs. Oftentimes, the error is caused either by strange input from the browser or an obscure edge case. In such a scenario, dropping a single RTP packet would result in a small lag which is far preferable to being kicked out of the room. This is very important when thinking about forthcoming production deployments of RTC Engine.
2. The library provides an NIF wrapper of libsrtp. I think whoever uses it, should decide if the error should if an exception being thrown, or discarded silently.

The behavior of `unprotect` was changed so that it is symmetric to `protect`. Changes to `membrane_rtp_plugin` should follow.
